### PR TITLE
Replace NIH, CDC, worldbank, and NCBI with zotero in reference imports.

### DIFF
--- a/.scripts/import_from_spreadsheets.py
+++ b/.scripts/import_from_spreadsheets.py
@@ -135,6 +135,13 @@ REFERENCE_FIELDS = [
   'refAvgLifeExpectancyInCountryAndYearOfEvent',
 ]
 
+REFS_TO_REPLACE = {
+  '^NIH$': 1087,
+  '^CDC$': 1088,
+  '.*worldbank\.org.*': 1089,
+  '^http\:\/\/www\.ncbi\.nlm\.nih\.gov$': 1090,
+}
+
 def import_refs(db, zot):
   items = []
   offset = 0
@@ -166,8 +173,20 @@ def import_refs(db, zot):
           else:
             print "%s: no zotero reference for %s" % (eidID, ref)
       else:
-        # this is a string reference
-        references.append(ref)
+        matched = False
+        for refPattern, zoteroId in REFS_TO_REPLACE.iteritems():
+          if re.match(refPattern, ref):
+            zotRef = find_zotero_ref(zoteroId, items)
+            if zotRef:
+              if not zotRef in references:
+                references.append(zotRef)
+            else:
+              print "%s: no zotero reference for %s, replaced with %s" % (eidId, ref, zoteroId)
+            matched = True
+            break
+        if not matched:
+          # this is a string reference
+          references.append(ref)
     events.update({'_id': event['_id']}, {'$set': {'references': references}})
 
 if __name__ == "__main__":


### PR DESCRIPTION
This connects to #29.

This takes NIH, CDC, World Bank, and some NCBI references in the spreadsheet and uses Zotero references for them. It might be better to change them in the spreadsheet, except for World Bank. We have specific World Bank URLs in some cases, and we probably don't want to create separate Zotero references for all of them, but it's nice to keep them in the spreadsheet in case we do want to use them later. 

We'll also want to change the app to use urls for references that have them in Zotero, but we might need to take out the ones that are Nico's dropbox. 
