### PR TITLE
Close -> direct transmission icon rename

### DIFF
--- a/client/stylesheets/event-icons.styl
+++ b/client/stylesheets/event-icons.styl
@@ -9,7 +9,7 @@
     padding 0 5px
     display inline-block
     line-height 65px
-  .type-close
+  .type-direct
     &::before
       content "c"
   .type-vector


### PR DESCRIPTION
This transmission icon broke when we renamed close transmission to direct in EIDR Statistics - #176.
