### PR TITLE
Hide certain fields when they have particular values. 

### DIFF
--- a/.scripts/import_from_spreadsheets.py
+++ b/.scripts/import_from_spreadsheets.py
@@ -56,6 +56,7 @@ def import_fields(file, db):
       d['_id'] = str(ObjectId())
       d['order'] = order
       order = order + 1
+      d['valuesToHide'] = [s.strip() for s in d['valuesToHide'].split(",")]
       parsedDropdownExplanations = dict()
       dropdownExplanations = d['dropdownExplanations'].split(";")
       for exp in dropdownExplanations:

--- a/client/controllers/events.coffee
+++ b/client/controllers/events.coffee
@@ -18,6 +18,10 @@ Template.events.settings = () ->
           if output in ['Not Found', 'Not Applicable']
             output = ''
 
+          # value should be hidden
+          if output in field.valuesToHide
+            output = ''
+
           # capitalize first letter
           if output.length > 1
             output = output.charAt(0).toUpperCase() + output.slice(1)

--- a/client/controllers/tables.coffee
+++ b/client/controllers/tables.coffee
@@ -5,9 +5,14 @@ references = () =>
   @grid.References
 
 Template.statsTable.showStat = (key, object) ->
-  if grid.Fields.findOne({"spreadsheetName" : key}).Quotations isnt 0
+  field = grid.Fields.findOne {"spreadsheetName": key}
+  if field.Quotations isnt 0
     quote = @Quotations
-  if object[key] isnt 'undefined' and object[key] isnt '' and object[key] isnt 'Not Applicable' and object[key] isnt 'Not Found'
+  if object[key] isnt 'undefined' and 
+     object[key] isnt '' and 
+     object[key] isnt 'Not Applicable' and 
+     object[key] isnt 'Not Found' and
+     object[key] not in field.valuesToHide
     object[key]
   else if object[key] is 'Not Found' and object[quote] and (object[quote] isnt 'undefined' or object[quote] isnt '')
     object[key]

--- a/client/views/event.jade
+++ b/client/views/event.jade
@@ -60,8 +60,8 @@ template(name="facts")
           +descriptionInline(field="eventTransmissionVal" event=../event)
         th Pathogen Host(s)
           +descriptionInline(field="hostVal" event=../event)
-        th Type of Zoonosis
-          +descriptionInline(field="zoonoticTypeVal" event=../event)
+        th Specific Host Involved in the Event
+          +descriptionInline(field="initiallyReportedHostVal" event=../event)
     tbody
       tr
         td(data-header="Event Transmission")
@@ -73,8 +73,8 @@ template(name="facts")
               li.unknown
         td(data-header="Pathogen Host(s)")
           span #{hostVal}
-        td(data-header="Type of Zoonosis")
-          span #{zoonoticTypeVal}
+        td(data-header="Specific Host Involved in the Event")
+          span #{initiallyReportedHostVal}
 
 template(name="description")
   .icon-wrap


### PR DESCRIPTION
This fixes #199.
This fixes #200.
This fixes #203.

I added a 'valuesToHide' column to the EIDR Statistics spreadsheet, with a comma-separated list of values that indicate we shouldn't show that field on the event page and should leave it blank in the table. 

I also removed Type of Zoonosis from the main facts after discussing with Zach. It's one of the fields that's hidden sometimes, so I'd rather not have the header change depending on the event, and reviewers so far find "transmission from infected animal" more useful than the zoonotic type. It's now specific host involved in the event.
