### PR TITLE
Adding a sitemap for event page indexing by search engines

### DIFF
--- a/server/router.coffee
+++ b/server/router.coffee
@@ -4,7 +4,7 @@ getEvents = () =>
 Router.route "/sitemap.xml", 
   where: 'server'
 .get () ->
-  ROOT_URL = process.env.ROOT_URL or "https://localhost/"
+  ROOT_URL = process.env.ROOT_URL or "//localhost/"
   if ROOT_URL.slice(-1) isnt "/"
     ROOT_URL += "/"
   @response.end """


### PR DESCRIPTION
This PR adds a sitemap.xml file which will hopefully cause google to index the individual event pages. I looked into using the Meteor spiderable package and while it might improve googlebot's ability to crawl sub-pages[1], I don't believe it will be a complete solution because the event table and map view will not contain links to all the events when rendered by phantomJS. The event map only renders links when the corresponding pop-up is opened, and the event table does not have unique urls for each page that the spider could crawl along. It might be useful to add the spiderable package in the future to support spiders that do not render JS pages like googlebot.

In order to check if the sitemap is working property the [google search console](https://www.google.com/webmasters/tools/home) may be of use. However, it requires someone to verify that they are the site manager. @aslagle @frosario I think it would be best for one of you to set this up. If the sitemap is working I would expect queries like `site:https://eidr.ecohealthalliance.org Seoul virus` to return results.

[1] The spiderable readme says "In order to have links between multiple pages on a site visible to spiders, apps must use real links (eg `<a href="/about">`) rather than simply re-rendering portions of the page when an element is clicked."
