### PR TITLE
Separate historical EIDR events from user submitted events

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -17,6 +17,7 @@ fuatsengul:leaflet
 accounts-base
 accounts-ui
 accounts-google
+accounts-password
 useraccounts:bootstrap
 useraccounts:iron-routing
 service-configuration

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,6 +1,7 @@
 accounts-base@1.2.7
 accounts-google@1.0.10
 accounts-oauth@1.1.13
+accounts-password@1.1.10
 accounts-ui@1.1.9
 accounts-ui-unstyled@1.1.12
 alanning:roles@1.2.15
@@ -32,6 +33,7 @@ diff-sequence@1.0.6
 ecmascript@0.4.4
 ecmascript-runtime@0.2.11
 ejson@1.0.12
+email@1.0.13
 fastclick@1.0.12
 fortawesome:fontawesome@4.5.0
 fuatsengul:leaflet@1.0.1
@@ -71,6 +73,7 @@ mongo-id@1.0.5
 mquandalle:jade@0.4.9
 mquandalle:jade-compiler@0.4.5
 natestrauser:analyticsjs@0.1.9
+npm-bcrypt@0.8.7
 npm-mongo@1.4.44
 oauth@1.1.11
 oauth2@1.1.10
@@ -87,9 +90,11 @@ retry@1.0.8
 routepolicy@1.0.11
 service-configuration@1.0.10
 session@1.1.6
+sha@1.0.8
 softwarerero:accounts-t9n@1.3.4
 spacebars@1.0.12
 spacebars-compiler@1.0.12
+srp@1.0.9
 standard-minifier-css@1.0.7
 standard-minifier-js@1.0.7
 stylus@2.512.1

--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -1,0 +1,17 @@
+Template.userEvent.onCreated ->
+	@editState = new ReactiveVar(false)
+
+Template.userEvent.helpers
+	isEditing: () ->
+		return Template.instance().editState.get()
+
+Template.userEvent.events
+	"click #edit, click #cancel-edit": (event, template) ->
+		template.editState.set(not template.editState.get())
+	
+	"submit #editEvent": (event, template) ->
+		event.preventDefault()
+		updatedName = event.target.eventName.value.trim()
+		if updatedName.length isnt 0
+			grid.UserEvents.update(@_id, {$set: {eventName: updatedName}})
+			template.editState.set(false)

--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -15,3 +15,13 @@ Template.userEvent.events
     if updatedName.length isnt 0
       grid.UserEvents.update(@_id, {$set: {eventName: updatedName}})
       template.editState.set(false)
+
+Template.createEvent.events
+  "submit #add-event": (e) ->
+    e.preventDefault()
+    newEvent = e.target.eventName.value
+    if newEvent.trim().length isnt 0
+      grid.UserEvents.insert({eventName: newEvent}, (error, result) ->
+        Router.go('user-event', {_id: result})
+      )
+      e.target.eventName.value = ''

--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -1,17 +1,17 @@
 Template.userEvent.onCreated ->
-	@editState = new ReactiveVar(false)
+  @editState = new ReactiveVar(false)
 
 Template.userEvent.helpers
-	isEditing: () ->
-		return Template.instance().editState.get()
+  isEditing: () ->
+    return Template.instance().editState.get()
 
 Template.userEvent.events
-	"click #edit, click #cancel-edit": (event, template) ->
-		template.editState.set(not template.editState.get())
-	
-	"submit #editEvent": (event, template) ->
-		event.preventDefault()
-		updatedName = event.target.eventName.value.trim()
-		if updatedName.length isnt 0
-			grid.UserEvents.update(@_id, {$set: {eventName: updatedName}})
-			template.editState.set(false)
+  "click #edit, click #cancel-edit": (event, template) ->
+    template.editState.set(not template.editState.get())
+  
+  "submit #editEvent": (event, template) ->
+    event.preventDefault()
+    updatedName = event.target.eventName.value.trim()
+    if updatedName.length isnt 0
+      grid.UserEvents.update(@_id, {$set: {eventName: updatedName}})
+      template.editState.set(false)

--- a/client/controllers/userEvents.coffee
+++ b/client/controllers/userEvents.coffee
@@ -1,7 +1,81 @@
-Template.createEvent.helpers
-  currentCount: () ->
-    return grid.UserEvents.find().count()
+Template.userEvents.onCreated () ->
+	@userEventFields = [
+		{
+			'Event table': '2',
+			Quotations: '0',
+			arrayName: '',
+			description: 'The name of the EID.',
+			displayName: 'Event Name',
+			spreadsheetName: 'eventName'
+		}
+	]
+	
+	@currentPage = new ReactiveVar(Session.get('events-current-page') or 0)
+	@rowsPerPage = new ReactiveVar(Session.get('events-rows-per-page') or 10)
+	@fieldVisibility = {}
+	@sortOrder = {}
+	@sortDirection = {}
+	
+	for field in @userEventFields
+		defaultVisibility = field['Event table'] is '2'
+		oldVisibility = Session.get('events-field-visible-' + field.spreadsheetName)
+		visibility = if _.isUndefined(oldVisibility) then defaultVisibility else oldVisibility
+		@fieldVisibility[field.spreadsheetName] = new ReactiveVar(visibility)
 		
+		defaultSortOrder = Infinity
+		oldSortOrder = Session.get('events-field-sort-order-' + field.spreadsheetName)
+		sortOrder = if _.isUndefined(oldSortOrder) then defaultSortOrder else oldSortOrder
+		@sortOrder[field.spreadsheetName] = new ReactiveVar(sortOrder)
+		
+		defaultSortDirection = 1
+		oldSortDirection = Session.get('events-field-sort-direction-' + field.spreadsheetName)
+		sortDirection = if _.isUndefined(oldSortDirection) then defaultSortDirection else oldSortDirection
+		@sortDirection[field.spreadsheetName] = new ReactiveVar(sortDirection)
+	
+	@autorun () =>
+		Session.set 'events-current-page', @currentPage.get()
+		Session.set 'events-rows-per-page', @rowsPerPage.get()
+		for field in @userEventFields
+			Session.set 'events-field-visible-' + field.spreadsheetName, @fieldVisibility[field.spreadsheetName].get()
+			Session.set 'events-field-sort-order-' + field.spreadsheetName, @sortOrder[field.spreadsheetName].get()
+			Session.set 'events-field-sort-direction-' + field.spreadsheetName, @sortDirection[field.spreadsheetName].get()
+
+Template.userEvents.helpers
+	userEvents: () ->
+		return grid.UserEvents.find()
+	
+	settings : () ->
+		fields = []
+		for field in Template.instance().userEventFields
+			fields.push {
+				key: field.spreadsheetName
+				label: field.displayName
+				isVisible: Template.instance().fieldVisibility[field.spreadsheetName]
+				sortOrder: Template.instance().sortOrder[field.spreadsheetName]
+				sortDirection: Template.instance().sortDirection[field.spreadsheetName]
+				sortable: not field.arrayName
+			}
+		
+		return {
+			id: 'user-events-table'
+			showColumnToggles: true
+			fields: fields
+			currentPage: Template.instance().currentPage
+			rowsPerPage: Template.instance().rowsPerPage
+			showRowCount: true
+		}
+
+Template.userEvents.events
+	"click .reactive-table tbody tr": (event) ->
+		if event.metaKey
+			url = Router.url "user-event", { eidID: @_id }
+			window.open(url, "_blank")
+		else
+			Router.go "user-event", { eidID: @_id }
+	"click .next-page, click .previous-page" : () ->
+		if (window.scrollY > 0 and window.innerHeight < 700)
+			$('body').animate({scrollTop:0,400})
+
 Template.createEvent.events
   "submit #add-event": (e) ->
     e.preventDefault()

--- a/client/controllers/userEvents.coffee
+++ b/client/controllers/userEvents.coffee
@@ -1,8 +1,6 @@
 Template.userEvents.onCreated () ->
   @userEventFields = [
     {
-      'Event table': '2',
-      Quotations: '0',
       arrayName: '',
       description: 'The name of the EID.',
       displayName: 'Event Name',
@@ -17,9 +15,8 @@ Template.userEvents.onCreated () ->
   @sortDirection = {}
   
   for field in @userEventFields
-    defaultVisibility = field['Event table'] is '2'
     oldVisibility = Session.get('events-field-visible-' + field.spreadsheetName)
-    visibility = if _.isUndefined(oldVisibility) then defaultVisibility else oldVisibility
+    visibility = if _.isUndefined(oldVisibility) then true else oldVisibility
     @fieldVisibility[field.spreadsheetName] = new ReactiveVar(visibility)
     
     defaultSortOrder = Infinity
@@ -68,20 +65,10 @@ Template.userEvents.helpers
 Template.userEvents.events
   "click .reactive-table tbody tr": (event) ->
     if event.metaKey
-      url = Router.url "user-event", { eidID: @_id }
+      url = Router.url "user-event", {_id: @_id}
       window.open(url, "_blank")
     else
-      Router.go "user-event", { eidID: @_id }
+      Router.go "user-event", {_id: @_id}
   "click .next-page, click .previous-page" : () ->
     if (window.scrollY > 0 and window.innerHeight < 700)
       $('body').animate({scrollTop:0,400})
-
-Template.createEvent.events
-  "submit #add-event": (e) ->
-    e.preventDefault()
-    newEvent = e.target.eventName.value
-    if newEvent.trim().length isnt 0
-      grid.UserEvents.insert({eventName: newEvent}, (error, result) ->
-        Router.go('user-event', {eidID: result})
-      )
-      e.target.eventName.value = ''

--- a/client/controllers/userEvents.coffee
+++ b/client/controllers/userEvents.coffee
@@ -1,86 +1,87 @@
 Template.userEvents.onCreated () ->
-	@userEventFields = [
-		{
-			'Event table': '2',
-			Quotations: '0',
-			arrayName: '',
-			description: 'The name of the EID.',
-			displayName: 'Event Name',
-			spreadsheetName: 'eventName'
-		}
-	]
-	
-	@currentPage = new ReactiveVar(Session.get('events-current-page') or 0)
-	@rowsPerPage = new ReactiveVar(Session.get('events-rows-per-page') or 10)
-	@fieldVisibility = {}
-	@sortOrder = {}
-	@sortDirection = {}
-	
-	for field in @userEventFields
-		defaultVisibility = field['Event table'] is '2'
-		oldVisibility = Session.get('events-field-visible-' + field.spreadsheetName)
-		visibility = if _.isUndefined(oldVisibility) then defaultVisibility else oldVisibility
-		@fieldVisibility[field.spreadsheetName] = new ReactiveVar(visibility)
-		
-		defaultSortOrder = Infinity
-		oldSortOrder = Session.get('events-field-sort-order-' + field.spreadsheetName)
-		sortOrder = if _.isUndefined(oldSortOrder) then defaultSortOrder else oldSortOrder
-		@sortOrder[field.spreadsheetName] = new ReactiveVar(sortOrder)
-		
-		defaultSortDirection = 1
-		oldSortDirection = Session.get('events-field-sort-direction-' + field.spreadsheetName)
-		sortDirection = if _.isUndefined(oldSortDirection) then defaultSortDirection else oldSortDirection
-		@sortDirection[field.spreadsheetName] = new ReactiveVar(sortDirection)
-	
-	@autorun () =>
-		Session.set 'events-current-page', @currentPage.get()
-		Session.set 'events-rows-per-page', @rowsPerPage.get()
-		for field in @userEventFields
-			Session.set 'events-field-visible-' + field.spreadsheetName, @fieldVisibility[field.spreadsheetName].get()
-			Session.set 'events-field-sort-order-' + field.spreadsheetName, @sortOrder[field.spreadsheetName].get()
-			Session.set 'events-field-sort-direction-' + field.spreadsheetName, @sortDirection[field.spreadsheetName].get()
+  @userEventFields = [
+    {
+      'Event table': '2',
+      Quotations: '0',
+      arrayName: '',
+      description: 'The name of the EID.',
+      displayName: 'Event Name',
+      spreadsheetName: 'eventName'
+    }
+  ]
+  
+  @currentPage = new ReactiveVar(Session.get('events-current-page') or 0)
+  @rowsPerPage = new ReactiveVar(Session.get('events-rows-per-page') or 10)
+  @fieldVisibility = {}
+  @sortOrder = {}
+  @sortDirection = {}
+  
+  for field in @userEventFields
+    defaultVisibility = field['Event table'] is '2'
+    oldVisibility = Session.get('events-field-visible-' + field.spreadsheetName)
+    visibility = if _.isUndefined(oldVisibility) then defaultVisibility else oldVisibility
+    @fieldVisibility[field.spreadsheetName] = new ReactiveVar(visibility)
+    
+    defaultSortOrder = Infinity
+    oldSortOrder = Session.get('events-field-sort-order-' + field.spreadsheetName)
+    sortOrder = if _.isUndefined(oldSortOrder) then defaultSortOrder else oldSortOrder
+    @sortOrder[field.spreadsheetName] = new ReactiveVar(sortOrder)
+    
+    defaultSortDirection = 1
+    oldSortDirection = Session.get('events-field-sort-direction-' + field.spreadsheetName)
+    sortDirection = if _.isUndefined(oldSortDirection) then defaultSortDirection else oldSortDirection
+    @sortDirection[field.spreadsheetName] = new ReactiveVar(sortDirection)
+  
+  @autorun () =>
+    Session.set 'events-current-page', @currentPage.get()
+    Session.set 'events-rows-per-page', @rowsPerPage.get()
+    for field in @userEventFields
+      Session.set 'events-field-visible-' + field.spreadsheetName, @fieldVisibility[field.spreadsheetName].get()
+      Session.set 'events-field-sort-order-' + field.spreadsheetName, @sortOrder[field.spreadsheetName].get()
+      Session.set 'events-field-sort-direction-' + field.spreadsheetName, @sortDirection[field.spreadsheetName].get()
 
 Template.userEvents.helpers
-	userEvents: () ->
-		return grid.UserEvents.find()
-	
-	settings : () ->
-		fields = []
-		for field in Template.instance().userEventFields
-			fields.push {
-				key: field.spreadsheetName
-				label: field.displayName
-				isVisible: Template.instance().fieldVisibility[field.spreadsheetName]
-				sortOrder: Template.instance().sortOrder[field.spreadsheetName]
-				sortDirection: Template.instance().sortDirection[field.spreadsheetName]
-				sortable: not field.arrayName
-			}
-		
-		return {
-			id: 'user-events-table'
-			showColumnToggles: true
-			fields: fields
-			currentPage: Template.instance().currentPage
-			rowsPerPage: Template.instance().rowsPerPage
-			showRowCount: true
-		}
+  userEvents: () ->
+    return grid.UserEvents.find()
+  
+  settings : () ->
+    fields = []
+    for field in Template.instance().userEventFields
+      fields.push {
+        key: field.spreadsheetName
+        label: field.displayName
+        isVisible: Template.instance().fieldVisibility[field.spreadsheetName]
+        sortOrder: Template.instance().sortOrder[field.spreadsheetName]
+        sortDirection: Template.instance().sortDirection[field.spreadsheetName]
+        sortable: not field.arrayName
+      }
+    
+    return {
+      id: 'user-events-table'
+      showColumnToggles: true
+      fields: fields
+      currentPage: Template.instance().currentPage
+      rowsPerPage: Template.instance().rowsPerPage
+      showRowCount: true
+    }
 
 Template.userEvents.events
-	"click .reactive-table tbody tr": (event) ->
-		if event.metaKey
-			url = Router.url "user-event", { eidID: @_id }
-			window.open(url, "_blank")
-		else
-			Router.go "user-event", { eidID: @_id }
-	"click .next-page, click .previous-page" : () ->
-		if (window.scrollY > 0 and window.innerHeight < 700)
-			$('body').animate({scrollTop:0,400})
+  "click .reactive-table tbody tr": (event) ->
+    if event.metaKey
+      url = Router.url "user-event", { eidID: @_id }
+      window.open(url, "_blank")
+    else
+      Router.go "user-event", { eidID: @_id }
+  "click .next-page, click .previous-page" : () ->
+    if (window.scrollY > 0 and window.innerHeight < 700)
+      $('body').animate({scrollTop:0,400})
 
 Template.createEvent.events
   "submit #add-event": (e) ->
     e.preventDefault()
     newEvent = e.target.eventName.value
     if newEvent.trim().length isnt 0
-      grid.UserEvents.insert
-        eventName: newEvent
-    e.target.eventName.value = ''
+      grid.UserEvents.insert({eventName: newEvent}, (error, result) ->
+        Router.go('user-event', {eidID: result})
+      )
+      e.target.eventName.value = ''

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -122,11 +122,11 @@ Router.route "/create-event",
 Router.route "/user-events",
   name: 'user-events'
 
-Router.route "/user-event/:eidID",
+Router.route "/user-event/:_id",
   name: 'user-event'
   waitOn: () ->
     [
-      Meteor.subscribe "userEvent", @params.eidID
+      Meteor.subscribe "userEvent", @params._id
     ]
   data: () ->
-    userEvent: UserEvents().findOne({'_id': @params.eidID})
+    userEvent: UserEvents().findOne({'_id': @params._id})

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -9,6 +9,9 @@ Comments = () ->
 
 Comments = () ->
   @grid.Comments
+ 
+UserEvents = () ->
+	@grid.UserEvents
 
 Router.configure
   layoutTemplate: "layout"
@@ -111,11 +114,19 @@ Router.route "/variable-definitions",
 
 Router.route "/create-event",
   name: 'create-event',
-  waitOn: () ->
-    [
-      Meteor.subscribe "userEvents"
-    ]
   onBeforeAction: () ->
     unless Meteor.userId()
       @redirect '/sign-in'
     @next()
+
+Router.route "/user-events",
+	name: 'user-events'
+
+Router.route "/user-event/:eidID",
+  name: 'user-event'
+  waitOn: () ->
+    [
+      Meteor.subscribe "userEvent", @params.eidID
+    ]
+  data: () ->
+    userEvent: UserEvents().findOne({'_id': @params.eidID})

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -11,7 +11,7 @@ Comments = () ->
   @grid.Comments
  
 UserEvents = () ->
-	@grid.UserEvents
+  @grid.UserEvents
 
 Router.configure
   layoutTemplate: "layout"

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -120,7 +120,7 @@ Router.route "/create-event",
     @next()
 
 Router.route "/user-events",
-	name: 'user-events'
+  name: 'user-events'
 
 Router.route "/user-event/:eidID",
   name: 'user-event'

--- a/client/views/createEvent.jade
+++ b/client/views/createEvent.jade
@@ -10,7 +10,6 @@ template(name="createEvent")
               label.control-label.col-md-2 Event Name
               .col-md-8
                 input.form-control(type='text', name='eventName')
-
             .row
               .col-md-3.col-md-offset-7
                 button#add-event.btn.btn-primary.btn-lg.btn-block(type='submit') Add Event

--- a/client/views/createEvent.jade
+++ b/client/views/createEvent.jade
@@ -1,6 +1,6 @@
 template(name="createEvent")
   .container-fluid
-    .container.content-block
+    .container
       .row
         .col-md-12
           h1 Create Emergence Event
@@ -14,7 +14,3 @@ template(name="createEvent")
             .row
               .col-md-3.col-md-offset-7
                 button#add-event.btn.btn-primary.btn-lg.btn-block(type='submit') Add Event
-
-      .row
-        .col-md-12
-          | Current user defined event count: {{currentCount}}

--- a/client/views/createEvent.jade
+++ b/client/views/createEvent.jade
@@ -7,9 +7,9 @@ template(name="createEvent")
  
           form#add-event.form-horizontal
             .form-group
-              label.control-label.col-md-2 Event Name
-              .col-md-8
+              label.control-label.col-sm-2 Event Name
+              .col-sm-8
                 input.form-control(type='text', name='eventName')
             .row
-              .col-md-3.col-md-offset-7
+              .col-sm-3.col-sm-offset-7
                 button#add-event.btn.btn-primary.btn-lg.btn-block(type='submit') Add Event

--- a/client/views/header.jade
+++ b/client/views/header.jade
@@ -20,10 +20,10 @@ template(name="navLinks")
     li(class="{{checkActive 'about'}}")
       a(href="{{pathFor 'about'}}") About
     li(class="{{checkActive 'events'}}")
-      a(href="{{pathFor 'events'}}") Emergence Events
+      a(href="{{pathFor 'events'}}") Historical Events
+    li(class="{{checkActive 'user-events'}}")
+      a(href="{{pathFor 'user-events'}}") Emergence Events
     if currentUser
-      li(class="{{checkActive 'create-event'}}")
-        a(href="{{pathFor 'create-event'}}") Create Events
       li(class="{{checkActive 'download'}}")
         a(href="{{pathFor 'download'}}") Download
     li(class="{{checkActive 'event-map'}}")

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -1,20 +1,22 @@
 template(name="userEvent")
-	.container-fluid.fact-sheet-wrap.event.space-btm-4
-		.container
-			.row
-				.col-lg-12.event-head
-					with userEvent
-						.basic-info
-							.row
-								if isEditing
-									form#editEvent
-										.col-md-9
-											input.form-control.input-lg(type='text', name='eventName', value='{{eventName}}')
-										.col-md-3
-											button#save-edit.btn.btn-primary.btn-lg(type='submit') Save
-											button#cancel-edit.btn.btn-default.btn-lg Cancel
-								else
-									.col-md-10
-										h1 {{eventName}}
-									.col-md-2
-										button#edit.btn.btn-default.btn-lg Edit
+  .container-fluid.fact-sheet-wrap.event.space-btm-4
+    .container
+      .row
+        .col-lg-12.event-head
+          with userEvent
+            .basic-info
+              .row
+                if isEditing
+                  form#editEvent
+                    .col-md-8
+                      input.form-control.input-lg(type='text', name='eventName', value='{{eventName}}')
+                    .col-md-2
+                      button#save-edit.btn.btn-primary.btn-lg.btn-block(type='submit') Save
+                    .col-md-2
+                      button#cancel-edit.btn.btn-default.btn-lg.btn-block Cancel
+                else
+                  .col-md-10
+                    h1 {{eventName}}
+                  .col-md-2
+                    if currentUser
+                      button#edit.btn.btn-default.btn-lg.btn-block Edit

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -8,15 +8,15 @@ template(name="userEvent")
               .row
                 if isEditing
                   form#editEvent
-                    .col-md-8
+                    .col-sm-8.space-btm-2
                       input.form-control.input-lg(type='text', name='eventName', value='{{eventName}}')
-                    .col-md-2
+                    .col-sm-2.space-btm-2
                       button#save-edit.btn.btn-primary.btn-lg.btn-block(type='submit') Save
-                    .col-md-2
-                      button#cancel-edit.btn.btn-default.btn-lg.btn-block Cancel
+                    .col-sm-2.space-btm-2
+                      button#cancel-edit.btn.btn-default.btn-lg.btn-block(type='button') Cancel
                 else
-                  .col-md-10
+                  .col-sm-10
                     h1 {{eventName}}
-                  .col-md-2
+                  .col-sm-2
                     if currentUser
                       button#edit.btn.btn-default.btn-lg.btn-block Edit

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -1,0 +1,20 @@
+template(name="userEvent")
+	.container-fluid.fact-sheet-wrap.event.space-btm-4
+		.container
+			.row
+				.col-lg-12.event-head
+					with userEvent
+						.basic-info
+							.row
+								if isEditing
+									form#editEvent
+										.col-md-9
+											input.form-control.input-lg(type='text', name='eventName', value='{{eventName}}')
+										.col-md-3
+											button#save-edit.btn.btn-primary.btn-lg(type='submit') Save
+											button#cancel-edit.btn.btn-default.btn-lg Cancel
+								else
+									.col-md-10
+										h1 {{eventName}}
+									.col-md-2
+										button#edit.btn.btn-default.btn-lg Edit

--- a/client/views/userEvents.jade
+++ b/client/views/userEvents.jade
@@ -1,0 +1,6 @@
+template(name="userEvents")
+	section.container.events
+		if currentUser
+			a.btn.btn-link(href="{{pathFor 'create-event'}}") Create New Event
+		
+		+reactiveTable collection="userEvents" settings=settings

--- a/client/views/userEvents.jade
+++ b/client/views/userEvents.jade
@@ -1,6 +1,8 @@
 template(name="userEvents")
-	section.container.events
-		if currentUser
-			a.btn.btn-link(href="{{pathFor 'create-event'}}") Create New Event
-		
-		+reactiveTable collection="userEvents" settings=settings
+  section.container.events
+    if currentUser
+      .row
+        .col-md-2.col-md-offset-10
+          a.btn.btn-link.btn-lg(href="{{pathFor 'create-event'}}") Create New Event
+
+    +reactiveTable collection="userEvents" settings=settings

--- a/collections/userEvents.coffee
+++ b/collections/userEvents.coffee
@@ -4,9 +4,13 @@ UserEvents = new Mongo.Collection "userEvents"
 @grid.UserEvents = UserEvents
 
 if Meteor.isServer
-  Meteor.publish "userEvents", () ->
-    UserEvents.find()
+  ReactiveTable.publish "userEvents", UserEvents, {}
+  
+  Meteor.publish "userEvent", (eidID) ->
+    UserEvents.find({'_id': eidID})
   
   UserEvents.allow
     insert: (userID, doc) ->
+      return Meteor.user()
+    update: (userId, doc, fieldNames, modifier) ->
       return Meteor.user()


### PR DESCRIPTION
I added a page for viewing all user added events as well as an event details page, using the existing event code as a template. The user event list is under the emergence events menu link and the previous events list is under the historical events link. The user event list page includes a link to the event creation page and after creating an event, the user is redirected to the details page for the new event, where the event name can be edited. I assume that in the future we'll be storing the displayed fields in a collection but they are hardcoded in an array for now.