### PR TITLE
Limit EIDR event creation to admin users

### DIFF
--- a/client/controllers/header.coffee
+++ b/client/controllers/header.coffee
@@ -1,7 +1,7 @@
 Template.navLinks.events
   'click' : (e) ->
     #check event.target's class to see if the click was meant to open/close a dropdown
-    if not $(e.target).hasClass("dropdown-toggle") and $('.navbar-toggle').is(':visible')
+    if not $(e.target).hasClass("dropdown-toggle-nav") and $('.navbar-toggle').is(':visible')
       $('.navbar-collapse').collapse('toggle')
 
 Template.navLinks.helpers

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -126,7 +126,7 @@ Router.route "/create-event",
   name: 'create-event',
   onBeforeAction: () ->
     unless Roles.userIsInRole(Meteor.userId(), ['admin'])
-      @redirect '/sign-in'
+      @redirect '/'
     @next()
 
 Router.route "/user-events",

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -125,7 +125,7 @@ Router.route "/variable-definitions",
 Router.route "/create-event",
   name: 'create-event',
   onBeforeAction: () ->
-    unless Meteor.userId()
+    unless Roles.userIsInRole(Meteor.userId(), ['admin'])
       @redirect '/sign-in'
     @next()
 

--- a/client/views/header.jade
+++ b/client/views/header.jade
@@ -14,9 +14,9 @@ template(name="navLinks")
   ul.nav.navbar-nav
     if isInRole "admin"
       li(class="dropdown {{checkActive 'create-account'}} {{checkActive 'admins'}}")
-        a.dropdown-toggle(href="#" role="button" data-toggle="dropdown") Admins
+        a.dropdown-toggle-nav(href="#" role="button" data-toggle="dropdown") Admins
           span.caret
-        ul.dropdown-menu
+        ul.dropdown-menu.nav-dd
           li(class="{{checkActive 'create-account'}}")
             a(href="{{pathFor 'create-account'}}") Create User Account
           li(class="{{checkActive 'admins'}}")

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -18,7 +18,7 @@ template(name="userEvent")
                   .col-sm-10
                     h1 {{eventName}}
                   .col-sm-2
-                    if currentUser
+                    if isInRole "admin"
                       button#edit.btn.btn-default.btn-lg.btn-block Edit
   .container.tables
     .row

--- a/client/views/userEvents.jade
+++ b/client/views/userEvents.jade
@@ -2,7 +2,7 @@ template(name="userEvents")
   .container
     h1 Tracked Events
   section.container.events
-    if currentUser
+    if isInRole "admin"
       .row
         .col-md-2.col-md-offset-10
           a.btn.btn-link.btn-lg(href="{{pathFor 'create-event'}}") Create New Event

--- a/collections/userEvents.coffee
+++ b/collections/userEvents.coffee
@@ -12,6 +12,6 @@ if Meteor.isServer
   UserEvents.allow
     insert: (userID, doc) ->
       doc.creationDate = new Date()
-      return Meteor.user()
+      return Roles.userIsInRole(Meteor.userId(), ['admin'])
     update: (userId, doc, fieldNames, modifier) ->
-      return Meteor.user()
+      return Roles.userIsInRole(Meteor.userId(), ['admin'])


### PR DESCRIPTION
Only admins can create and update events. Buttons associated with these tasks have been hidden for all other users.