### PR TITLE
EIDR Admins can create other admin accounts

### DIFF
--- a/client/controllers/account.coffee
+++ b/client/controllers/account.coffee
@@ -10,3 +10,4 @@ AccountsTemplates.configureRoute 'signIn',
 
 AccountsTemplates.configure
   hideSignUpLink: true
+  showForgotPasswordLink: true

--- a/client/controllers/adminUser.coffee
+++ b/client/controllers/adminUser.coffee
@@ -9,7 +9,9 @@ Template.adminUser.helpers
     this.profile.name
 
   email : () ->
-    this.services.google.email
+    if this.services.google
+      return this.services.google.email
+    return this.emails[0].address
 
 Template.adminUser.events
   'click .make-admin' : (event) ->
@@ -19,3 +21,13 @@ Template.adminUser.events
   'click .remove-admin' : (event) ->
     userId = event.target.getAttribute('user-id')
     Meteor.call('removeAdmin', userId)
+
+Template.createAccount.events
+  'submit #add-account': (event) ->
+    event.preventDefault()
+    
+    name = event.target.name.value.trim()
+    email = event.target.email.value.trim()
+    makeAdmin = event.target.admin.checked
+    
+    Meteor.call('createAccount', email, name, makeAdmin)

--- a/client/controllers/adminUser.coffee
+++ b/client/controllers/adminUser.coffee
@@ -30,4 +30,9 @@ Template.createAccount.events
     email = event.target.email.value.trim()
     makeAdmin = event.target.admin.checked
     
-    Meteor.call('createAccount', email, name, makeAdmin)
+    if name.length and email.length
+      Meteor.call('createAccount', email, name, makeAdmin, (error, result) ->
+        if error
+          if error.error is 'allUsers.createAccount.exists'
+            alert("The specified email address is already being used.")
+      )

--- a/client/controllers/header.coffee
+++ b/client/controllers/header.coffee
@@ -1,5 +1,6 @@
 Template.navLinks.events
   'click' : (e) ->
+    #check event.target to see if the click was meant to open a dropdown
     if $('.navbar-toggle').is(':visible')
       $('.navbar-collapse').collapse('toggle')
 

--- a/client/controllers/header.coffee
+++ b/client/controllers/header.coffee
@@ -1,6 +1,6 @@
 Template.navLinks.events
   'click' : (e) ->
-    #check event.target to see if the click was meant to open a dropdown
+    #check event.target's class to see if the click was meant to open/close a dropdown
     if not $(e.target).hasClass("dropdown-toggle") and $('.navbar-toggle').is(':visible')
       $('.navbar-collapse').collapse('toggle')
 

--- a/client/controllers/header.coffee
+++ b/client/controllers/header.coffee
@@ -1,7 +1,7 @@
 Template.navLinks.events
   'click' : (e) ->
     #check event.target to see if the click was meant to open a dropdown
-    if $('.navbar-toggle').is(':visible')
+    if not $(e.target).hasClass("dropdown-toggle") and $('.navbar-toggle').is(':visible')
       $('.navbar-collapse').collapse('toggle')
 
 Template.navLinks.helpers

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -72,6 +72,16 @@ Router.route "/admins",
     adminUsers: Meteor.users.find({roles: {$in: ["admin"]}})
     nonAdminUsers: Meteor.users.find({roles: {$not: {$in: ["admin"]}}})
 
+Router.route "/create-account",
+  name: 'create-account'
+  onBeforeAction: () ->
+    unless Roles.userIsInRole(Meteor.userId(), ['admin'])
+      @redirect '/'
+    @next()
+  waitOn: ()->
+    #Wait on roles subscription so onBeforeAction() doesn't run twice
+    Meteor.subscribe "roles"
+
 Router.route "/comments",
   name: 'adminComments'
   onBeforeAction: () ->

--- a/client/stylesheets/events.import.styl
+++ b/client/stylesheets/events.import.styl
@@ -25,7 +25,7 @@
       position absolute
       left 15px
 
-.dropdown-toggle
+.reactive-table-columns-dropdown .dropdown-toggle
   font-size 0
   &::before,
   &::after

--- a/client/stylesheets/header.import.styl
+++ b/client/stylesheets/header.import.styl
@@ -34,7 +34,10 @@
     color white
     @extend .dark-shadow
 
-.dropdown-menu 
+.navbar-nav .open .dropdown-menu
+  background-color secondary-light
+
+.dropdown-menu
   > li > a
     padding 3px 20px
 

--- a/client/stylesheets/header.import.styl
+++ b/client/stylesheets/header.import.styl
@@ -12,7 +12,8 @@
 .navbar-nav
   margin-right -15px
 
-.navbar-default .navbar-nav > li > a
+.navbar-default .navbar-nav > li > a,
+.navbar-default .navbar-nav .open .dropdown-menu > li > a
   font-size 14px
   color d-gray
   &:hover
@@ -22,7 +23,13 @@
     
 .navbar-default .navbar-nav > .active > a, 
 .navbar-default .navbar-nav > .active > a:hover, 
-.navbar-default .navbar-nav > .active > a:focus
+.navbar-default .navbar-nav > .active > a:focus,
+.navbar-default .navbar-nav .open .dropdown-menu > .active > a,
+.navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover,
+.navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus,
+.navbar-default .navbar-nav > .open > a,
+.navbar-default .navbar-nav > .open > a:hover,
+.navbar-default .navbar-nav > .open > a:focus
     background-color secondary
     color white
     @extend .dark-shadow

--- a/client/stylesheets/variables.import.styl
+++ b/client/stylesheets/variables.import.styl
@@ -19,7 +19,7 @@ warning = #EFAC56
 tableRadius = 5px
 table-border = 1px solid #DDD
 
-header-height = 70px + 2 // 2px border
+header-height = 200px + 2 // 2px border
 mobile-header-height = 60px + 2 // 2px border
 
 footer-height = 100px

--- a/client/stylesheets/variables.import.styl
+++ b/client/stylesheets/variables.import.styl
@@ -19,7 +19,7 @@ warning = #EFAC56
 tableRadius = 5px
 table-border = 1px solid #DDD
 
-header-height = 200px + 2 // 2px border
+header-height = 70px + 2 // 2px border
 mobile-header-height = 60px + 2 // 2px border
 
 footer-height = 100px

--- a/client/views/createAccount.jade
+++ b/client/views/createAccount.jade
@@ -1,0 +1,25 @@
+template(name="createAccount")
+  .container-fluid
+    .container
+      .row
+        .col-md-12
+          h1 Create New Account
+ 
+          form#add-account.form-horizontal
+            .form-group
+              label.control-label.col-sm-2 Email
+              .col-sm-8
+                input.form-control(type='text', name='email')
+            .form-group
+              label.control-label.col-sm-2 Name
+              .col-sm-8
+                input.form-control(type='text', name='name')
+            .form-group
+              .col-sm-8.col-sm-offset-2
+                .checkbox
+                  label
+                    input(type="checkbox", name="admin")
+                    | Make Admin
+            .row
+              .col-sm-3.col-sm-offset-7
+                button#add-event.btn.btn-primary.btn-lg.btn-block(type='submit') Add User

--- a/client/views/header.jade
+++ b/client/views/header.jade
@@ -13,8 +13,14 @@ template(name="header")
 template(name="navLinks")
   ul.nav.navbar-nav
     if isInRole "admin"
-      li(class="{{checkActive 'admins'}}")
-        a(href="{{pathFor 'admins'}}") Admins
+      li(class="dropdown {{checkActive 'create-account'}} {{checkActive 'admins'}}")
+        a.dropdown-toggle(href="#" role="button" data-toggle="dropdown") Admins
+          span.caret
+        ul.dropdown-menu
+          li(class="{{checkActive 'create-account'}}")
+            a(href="{{pathFor 'create-account'}}") Create New Account
+          li(class="{{checkActive 'admins'}}")
+            a(href="{{pathFor 'admins'}}") Current Accounts
       li(class="{{checkActive 'comments'}}")
         a(href="{{pathFor 'adminComments'}}") Comments
     li(class="{{checkActive 'about'}}")

--- a/client/views/header.jade
+++ b/client/views/header.jade
@@ -18,9 +18,9 @@ template(name="navLinks")
           span.caret
         ul.dropdown-menu
           li(class="{{checkActive 'create-account'}}")
-            a(href="{{pathFor 'create-account'}}") Create New Account
+            a(href="{{pathFor 'create-account'}}") Create User Account
           li(class="{{checkActive 'admins'}}")
-            a(href="{{pathFor 'admins'}}") Current Accounts
+            a(href="{{pathFor 'admins'}}") Current User Accounts
       li(class="{{checkActive 'comments'}}")
         a(href="{{pathFor 'adminComments'}}") Comments
     li(class="{{checkActive 'about'}}")

--- a/collections/allUsers.coffee
+++ b/collections/allUsers.coffee
@@ -26,18 +26,19 @@ if Meteor.isServer
     createAccount: (email, profileName, giveAdminRole) ->
       if Roles.userIsInRole(Meteor.userId(), ['admin'])
         existingUser = Accounts.findUserByEmail(email)
-        if not existingUser
-          if Meteor.isServer
-            newUserId = Accounts.createUser({
-              email: email,
-              profile: {
-                name: profileName
-              }
-            })
-            
-            if giveAdminRole
-              Roles.addUsersToRoles(newUserId, ['admin'])
-            Accounts.sendEnrollmentEmail(newUserId)
-            Router.go('admins')
+        if existingUser
+          throw new Meteor.Error('allUsers.createAccount.exists')
+        else
+          newUserId = Accounts.createUser({
+            email: email,
+            profile: {
+              name: profileName
+            }
+          })
+          
+          if giveAdminRole
+            Roles.addUsersToRoles(newUserId, ['admin'])
+          Accounts.sendEnrollmentEmail(newUserId)
+          Router.go('admins')
       else
         throw new Meteor.Error(403, "Not authorized")


### PR DESCRIPTION
I made the admins menu a dropdown with 2 options and changed some of the styling for dropdown menus in the header. The current user accounts option goes to what was previously the admins link and the create user account goes to the form I added for creating a new user where an admin can specify an email address and profile name for a new account. A welcome email is then sent to the address with a link for setting the account's password. I also added a forgot password link to the log in template. Both of these emails are using the default email templates so they'll probably need customized at some point. I also think there should be a user profile page where users can change their account settings.