### PR TITLE
Add EIDR "Editor Summary" free text field to events

### DIFF
--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -15,8 +15,9 @@ Template.userEvent.events
   "submit #editEvent": (event, template) ->
     event.preventDefault()
     updatedName = event.target.eventName.value.trim()
+    updatedSummary = event.target.eventSummary.value.trim()
     if updatedName.length isnt 0
-      grid.UserEvents.update(@_id, {$set: {eventName: updatedName}})
+      grid.UserEvents.update(@_id, {$set: {eventName: updatedName, summary: updatedSummary}})
       template.editState.set(false)
 
 Template.createEvent.events

--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -7,8 +7,6 @@ Template.userEvent.onCreated ->
 Template.userEvent.helpers
   isEditing: () ->
     return Template.instance().editState.get()
-  summarySections: () ->
-    return @summary.split("\n")
 
 Template.userEvent.events
   "click #edit, click #cancel-edit": (event, template) ->

--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -7,6 +7,8 @@ Template.userEvent.onCreated ->
 Template.userEvent.helpers
   isEditing: () ->
     return Template.instance().editState.get()
+  summarySections: () ->
+    return @summary.split("\n")
 
 Template.userEvent.events
   "click #edit, click #cancel-edit": (event, template) ->

--- a/client/stylesheets/event.import.styl
+++ b/client/stylesheets/event.import.styl
@@ -167,3 +167,6 @@
         border-bottom table-border
         width 100%
         margin-bottom 15px
+
+.abstract
+  white-space pre

--- a/client/views/createEvent.jade
+++ b/client/views/createEvent.jade
@@ -11,6 +11,9 @@ template(name="createEvent")
               .col-sm-8
                 input.form-control(type='text', name='eventName')
             .form-group
+              label.control-label.col-sm-2 Event Summary
+              .col-sm-8
+                textarea.form-control(name='eventSummary', rows='15')
               label.control-label.col-sm-2 Locations
               .col-sm-8
                 +locationSelect2

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -27,9 +27,13 @@ template(name="userEvent")
                 .row
                   .col-md-12
                     if summary
-                      p.abstract {{summary}}
+                      each summarySections
+                        if this.length
+                          p {{this}}
+                        else
+                          br
                     else
-                      p.abstract No summary available.
+                      p No summary available.
   
   .container.tables
     .row

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -27,13 +27,9 @@ template(name="userEvent")
                 .row
                   .col-md-12
                     if summary
-                      each summarySections
-                        if this.length
-                          p {{this}}
-                        else
-                          br
+                      p.abstract {{summary}}
                     else
-                      p No summary available.
+                      p.abstract No summary available.
   
   .container.tables
     .row

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -5,21 +5,31 @@ template(name="userEvent")
         .col-lg-12.event-head
           with userEvent
             .basic-info
-              .row
-                if isEditing
-                  form#editEvent
-                    .col-sm-8.space-btm-2
-                      input.form-control.input-lg(type='text', name='eventName', value='{{eventName}}')
-                    .col-sm-2.space-btm-2
+              if isEditing
+                form#editEvent.form-horizontal
+                  .form-group
+                    .col-sm-2.col-md-push-8.space-btm-2
                       button#save-edit.btn.btn-primary.btn-lg.btn-block(type='submit') Save
-                    .col-sm-2.space-btm-2
+                    .col-sm-2.col-md-push-8.space-btm-2
                       button#cancel-edit.btn.btn-default.btn-lg.btn-block(type='button') Cancel
-                else
-                  .col-sm-10
-                    h1 {{eventName}}
-                  .col-sm-2
-                    if isInRole "admin"
+                    .col-sm-8.col-md-pull-4
+                      input.form-control.input-lg(type='text', name='eventName', value='{{eventName}}', placeholder="Event name")
+                  .form-group
+                    .col-md-12
+                      textarea.form-control(name="eventSummary", placeholder="Event summary", rows="15") {{summary}}
+              else
+                .row
+                  .col-sm-2.col-md-push-10
+                    if currentUser
                       button#edit.btn.btn-default.btn-lg.btn-block Edit
+                  .col-sm-10.col-md-pull-2.space-btm-2
+                    h1 {{eventName}}
+                .row
+                  .col-md-12
+                    if summary
+                      p.abstract {{summary}}
+                    else
+                      p.abstract No summary available.
   
   .container.tables
     .row


### PR DESCRIPTION
I added a textarea for including an event summary. Since the edit form now has more than one input, the save and cancel buttons looked weird in small view ports because they went between the name and summary inputs. I rearranged the form a little bit to put the buttons at the top of the form for small view ports and used bootstrap push and pull classes to keep them to the right of the name input for larger view ports. While this looks ok, it messes up the natural tab order of the elements and I'm not sure how big of a concern that will be.